### PR TITLE
Fix typo in test

### DIFF
--- a/tests/test_build_meta_learner.py
+++ b/tests/test_build_meta_learner.py
@@ -204,7 +204,7 @@ class TestBuildMetaLearner(unittest.TestCase):
             self.output_path,
             self.results_meta_learner_en
         )))
-        self.assertEquals(
+        self.assertEqual(
             len(best_meta_learner_per_target_variable[self.target_variables[0]]),
             1, 
             "1 meta-learner per target variable"


### PR DESCRIPTION
This PR fixes a simple typo in one test where `self.assertEquals` should be `self.assertEqual`.

Upon this change running `python -m unittest -v` now succeeds.